### PR TITLE
broadcast server latency should be in msec

### DIFF
--- a/src/dsp/smoothing_filter.rs
+++ b/src/dsp/smoothing_filter.rs
@@ -22,6 +22,9 @@ impl SmoothingFilter {
         self.last_output = input * self.coef + (1.0 - self.coef) * self.last_output;
         self.last_output
     }
+    pub fn get_last_output(&self) -> f64 {
+        self.last_output
+    }
 }
 
 impl fmt::Display for SmoothingFilter {

--- a/src/server/audio_thread.rs
+++ b/src/server/audio_thread.rs
@@ -1,8 +1,14 @@
 use crate::{
-    common::{box_error::BoxError, jam_packet::JamMessage},
+    common::{
+        box_error::BoxError,
+        jam_packet::{JamMessage, JAM_HEADER_SIZE},
+        stream_time_stat::MicroTimer,
+    },
     server::player_list::{get_micro_time, PlayerList},
 };
 use std::{io::ErrorKind, net::UdpSocket, sync::mpsc, time::Duration};
+
+use super::player_list::MAX_LOOP_TIME;
 
 pub fn run(port: u32, audio_tx: mpsc::Sender<serde_json::Value>) -> Result<(), BoxError> {
     // So let's create a UDP socket and listen for shit
@@ -10,7 +16,7 @@ pub fn run(port: u32, audio_tx: mpsc::Sender<serde_json::Value>) -> Result<(), B
     sock.set_read_timeout(Some(Duration::new(1, 0)))?;
     let mut players = PlayerList::build();
     let mut msg = JamMessage::build();
-    let mut last_latency_update = get_micro_time();
+    let mut latency_update_timer = MicroTimer::build(get_micro_time(), 2_000_000);
 
     loop {
         let res = sock.recv_from(msg.get_buffer());
@@ -20,12 +26,11 @@ pub fn run(port: u32, audio_tx: mpsc::Sender<serde_json::Value>) -> Result<(), B
         players.prune(now_time);
         match res {
             Ok((amt, src)) => {
-                if now_time > (last_latency_update + 1000000) {
-                    println!("now: {}, last_update: {}", now_time, last_latency_update);
-                    last_latency_update = now_time;
+                if latency_update_timer.expired(now_time) {
+                    latency_update_timer.reset(now_time);
                     audio_tx.send(players.get_latency())?;
                     //     println!("got {} bytes from {}", amt, src);
-                    //     println!("player: {}", players);
+                    // println!("player: {}", players);
                     //     println!("msg: {}", msg);
                 }
                 // check if the packet was good
@@ -34,15 +39,15 @@ pub fn run(port: u32, audio_tx: mpsc::Sender<serde_json::Value>) -> Result<(), B
                 }
                 // println!("rcv: {}", msg);
                 // Update this player with the current time
-                let mut time_diff: u128 = 5000;
-                let packet_time = <u64 as TryInto<u128>>::try_into(msg.get_server_time()).unwrap();
+                let mut time_diff: u128 = MAX_LOOP_TIME;
+                let packet_time = msg.get_server_time() as u128;
                 if now_time > packet_time {
                     time_diff = now_time - packet_time;
                 }
                 players.update_player(now_time, time_diff, msg.get_client_id(), src);
 
                 // set the server timestamp
-                msg.set_server_time(now_time.try_into()?);
+                msg.set_server_time(now_time as u64);
                 // println!("xmit: {}", msg);
 
                 // Broadcast
@@ -51,6 +56,9 @@ pub fn run(port: u32, audio_tx: mpsc::Sender<serde_json::Value>) -> Result<(), B
                         // don't send echo back
                         // send the packet
                         sock.send_to(&msg.get_buffer()[0..amt], player.address)?;
+                    } else {
+                        // Send just a header to keep the timer looping around
+                        sock.send_to(&msg.get_buffer()[0..JAM_HEADER_SIZE], player.address)?;
                     }
                 }
             }

--- a/src/sound/jam_engine.rs
+++ b/src/sound/jam_engine.rs
@@ -136,6 +136,9 @@ impl JamEngine {
             match _res {
                 Ok(_v) => {
                     // got a network packet
+                    // Set the server timestamp on xmit packets to loop it back to broadcast server
+                    self.xmit_message
+                        .set_server_time(self.recv_message.get_server_time());
                     // Figure out what channel this guy belongs to
                     let (c1, c2) = self.recv_message.decode_audio();
                     if c1.len() > 0 {


### PR DESCRIPTION
Fixes #22

1) use smoothing filter on Player for latency stats
2) send header only packets to the sender to keep loop timing going with just one person in room
3) use MicroTimer in audio thread to signal when to send latency update to the room
4) convert the latency values from microseconds to milliseconds
5) get rid of serde_json serialization of Player (not used)