### PR TITLE
Improve Jitter Buffer

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,7 @@ num-traits = "0.2.15"
 rustfft = "6.1.0"
 mac_address = "1.1.4"
 socket2 = "0.5.1"
+rand = "0.8.5"
 
 [build-dependencies]
 vergen = "7.5.0"

--- a/src/dsp/attack_hold_release.rs
+++ b/src/dsp/attack_hold_release.rs
@@ -10,7 +10,7 @@ pub struct AttackHoldRelease<T> {
     attack_release_ouput: T,
     hold_time_count: usize,
     max_hold_time_count: usize,
-    last_output: T,
+    pub last_output: T,
 }
 
 impl<T: Float + FromPrimitive> AttackHoldRelease<T> {

--- a/src/dsp/power_meter.rs
+++ b/src/dsp/power_meter.rs
@@ -18,8 +18,8 @@ impl PowerMeter {
         PowerMeter {
             peak: PeakDetector::build(0.01, 0.1, 2666.6),
             avg: SmoothingFilter::build(0.01, 2666.6),
-            last_peak: 0.0,
-            last_avg: 0.0,
+            last_peak: -60.0,
+            last_avg: -60.0,
         }
     }
     pub fn get_peak(&self) -> f64 {

--- a/src/sound/channel_strip.rs
+++ b/src/sound/channel_strip.rs
@@ -71,7 +71,7 @@ impl ChannelStrip {
     /// settings for gain and fade
     pub fn mix_into(&mut self, out_a: &mut [f32], out_b: &mut [f32]) -> () {
         // First get some data from the buff
-        let samps = self.buffer.get(out_a.len());
+        let samps = self.buffer.get(out_a.len(), self.level.get_avg());
         self.level.add_frame(&samps, self.gain);
         let mut i: usize = 0;
         for v in samps {

--- a/src/sound/mixer.rs
+++ b/src/sound/mixer.rs
@@ -111,7 +111,7 @@ impl fmt::Display for Mixer {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "\n")?;
         for c in &self.strips {
-            if c.get_depth() > 0.01 {
+            if c.get_depth() > 0.1 {
                 write!(f, " {}", c)?;
             }
         }


### PR DESCRIPTION
Fixes #53

Adds low and high water marks to jitterbuffer.  Low water for fill level, and high water for purge level. low water fill uses AttachHoldDecay triggered when the buffer is getting low.  high water uses depth deviation measure (filtered with a SmoothingFilter) to decide when to throw away excess data.

checks sequence numbers of incoming packets to count drops.

Pass drops through to levelEvent

First shot at comfort noise fill on packet starves.  Generates random noise  gained to the last power level of the frame.  I'm sure there are many PhDs about how to do this.

