### PR TITLE
Mfvargo/issue55

### DIFF
--- a/examples/darius.rs
+++ b/examples/darius.rs
@@ -1,5 +1,5 @@
-use rtjam_rust::common::box_error::BoxError;
 use rtjam_rust::common::websocket::websocket_thread;
+use rtjam_rust::common::{box_error::BoxError, websock_message::WebsockMessage};
 use std::{
     sync::mpsc,
     thread::{self, sleep},
@@ -9,10 +9,8 @@ use std::{
 fn main() -> Result<(), BoxError> {
     // most simple app to test websocket
 
-    let (_to_ws_tx, to_ws_rx): (
-        mpsc::Sender<serde_json::Value>,
-        mpsc::Receiver<serde_json::Value>,
-    ) = mpsc::channel();
+    let (_to_ws_tx, to_ws_rx): (mpsc::Sender<WebsockMessage>, mpsc::Receiver<WebsockMessage>) =
+        mpsc::channel();
     let (from_ws_tx, from_ws_rx): (
         mpsc::Sender<serde_json::Value>,
         mpsc::Receiver<serde_json::Value>,

--- a/src/common.rs
+++ b/src/common.rs
@@ -1,8 +1,20 @@
 //! These modules are shared among both the client and server executables for rtjam.
+//!
+
+use std::time::{SystemTime, UNIX_EPOCH};
+// Get the time in microseconds
+pub fn get_micro_time() -> u128 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap()
+        .as_micros()
+}
+
 pub mod box_error;
 pub mod config;
 pub mod jam_nation_api;
 pub mod jam_packet;
+pub mod player;
 pub mod room;
 pub mod sock_with_tos;
 pub mod stream_time_stat;

--- a/src/common.rs
+++ b/src/common.rs
@@ -19,3 +19,4 @@ pub mod room;
 pub mod sock_with_tos;
 pub mod stream_time_stat;
 pub mod websocket;
+pub mod websock_message;

--- a/src/common/player.rs
+++ b/src/common/player.rs
@@ -1,27 +1,39 @@
+//! Struct use to track a players packet stream
+//!
+//! used by both sound and broadcast components.  
 use crate::dsp::smoothing_filter::SmoothingFilter;
 use serde::Serialize;
+use std::fmt;
 use std::net::SocketAddr;
 
+use super::stream_time_stat::StreamTimeStat;
+
 // This is how long a player lasts until we boot them (if they go silent)
-const EXPIRATION_IN_MICROSECONDS: u128 = 1_000_000;
+pub const EXPIRATION_IN_MICROSECONDS: u128 = 1_000_000;
 // represents an empty slot (legacy vst hangover)
-const EMPTY_SLOT: u32 = 40000;
+pub const EMPTY_SLOT: u32 = 40000;
 // represents maximum loop time that will be counted
 pub const MAX_LOOP_TIME: u128 = 100_000;
+// number of histogram buckets
+const HISTOGRAM_BUCKETS: usize = 15;
 
 /// Structure that represents a person in a room.  Used by both sound and broadcast components
 ///
 /// It has an ID, (assigned by rtjam-nation when they join a room)
+/// It also has a SocketAddr used by the broadcast server to do the multicast
 /// The keep_alive is used to time them out if we have not heard from them for over a second (no packets)
+/// It has the sequence number assigned by the packet originator and uses that to track dropped packets
+/// lastly it has some stat objects to characterize the packet stream (histogram, loop stats and packet arrival stats)
 #[derive(Serialize)]
 pub struct Player {
-    address: SocketAddr,            // key used by broadcast
-    client_id: u32,                 // key used by sound
-    keep_alive: u128,               // last time we saw this player
-    seq: u32,                       // packet sequence number
-    drops: usize,                   // dropped packet counter
-    hist: [usize; 10],              // histogram of packet arrivals
-    pub loop_stat: SmoothingFilter, // statistics about packet frequency
+    pub address: SocketAddr,          // key used by broadcast
+    pub client_id: u32,               // key used by sound
+    keep_alive: u128,                 // last time we saw this player
+    seq: u32,                         // packet sequence number
+    drops: usize,                     // dropped packet counter
+    hist: [usize; HISTOGRAM_BUCKETS], // histogram of packet arrivals
+    loop_stat: SmoothingFilter,       // statistics about packet loop time
+    pack_stats: StreamTimeStat,       // interarrival stats
 }
 
 impl Player {
@@ -31,16 +43,20 @@ impl Player {
             keep_alive: now_time,
             seq: 0,
             drops: 0,
-            hist: [0; 10],
+            hist: [0; HISTOGRAM_BUCKETS],
             address: addr,
             loop_stat: SmoothingFilter::build(0.5, 2666.6),
+            pack_stats: StreamTimeStat::new(100),
         }
     }
     pub fn get_drops(&self) -> usize {
         self.drops
     }
+    pub fn get_last_loop(&self) -> f64 {
+        self.loop_stat.get_last_output()
+    }
     pub fn clear(&mut self) -> () {
-        self.hist = [0; 10];
+        self.hist = [0; HISTOGRAM_BUCKETS];
         self.client_id = EMPTY_SLOT;
         self.keep_alive = 0;
         self.seq = 0;
@@ -48,8 +64,9 @@ impl Player {
     }
     pub fn update(&mut self, now: u128, id: u32, loop_time: u128, seq: u32) -> () {
         if self.keep_alive <= now {
-            let idx: usize = ((now - self.keep_alive) / 2667) as usize; // 2910 microsec per 128 sample frame
-            self.hist[idx.clamp(0, 9)] += 1;
+            self.pack_stats.add_sample((now - self.keep_alive) as f64);
+            let idx: usize = ((now - self.keep_alive) / 2667) as usize; // 2667 microsec per 128 sample frame
+            self.hist[idx.clamp(0, HISTOGRAM_BUCKETS - 1)] += 1;
         }
         if loop_time < MAX_LOOP_TIME {
             // Only count loop times less than 100msec
@@ -72,6 +89,12 @@ impl Player {
     }
 }
 
+impl fmt::Display for Player {
+    // This trait requires `fmt` with this exact signature.
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "{}", serde_json::to_string(&self).unwrap())
+    }
+}
 #[cfg(test)]
 mod test_player {
     use crate::common::get_micro_time;

--- a/src/common/player.rs
+++ b/src/common/player.rs
@@ -1,0 +1,90 @@
+use crate::dsp::smoothing_filter::SmoothingFilter;
+use serde::Serialize;
+use std::net::SocketAddr;
+
+// This is how long a player lasts until we boot them (if they go silent)
+const EXPIRATION_IN_MICROSECONDS: u128 = 1_000_000;
+// represents an empty slot (legacy vst hangover)
+const EMPTY_SLOT: u32 = 40000;
+// represents maximum loop time that will be counted
+pub const MAX_LOOP_TIME: u128 = 100_000;
+
+/// Structure that represents a person in a room.  Used by both sound and broadcast components
+///
+/// It has an ID, (assigned by rtjam-nation when they join a room)
+/// The keep_alive is used to time them out if we have not heard from them for over a second (no packets)
+#[derive(Serialize)]
+pub struct Player {
+    address: SocketAddr,            // key used by broadcast
+    client_id: u32,                 // key used by sound
+    keep_alive: u128,               // last time we saw this player
+    seq: u32,                       // packet sequence number
+    drops: usize,                   // dropped packet counter
+    hist: [usize; 10],              // histogram of packet arrivals
+    pub loop_stat: SmoothingFilter, // statistics about packet frequency
+}
+
+impl Player {
+    pub fn new(now_time: u128, id: u32, addr: SocketAddr) -> Player {
+        Player {
+            client_id: id,
+            keep_alive: now_time,
+            seq: 0,
+            drops: 0,
+            hist: [0; 10],
+            address: addr,
+            loop_stat: SmoothingFilter::build(0.5, 2666.6),
+        }
+    }
+    pub fn get_drops(&self) -> usize {
+        self.drops
+    }
+    pub fn clear(&mut self) -> () {
+        self.hist = [0; 10];
+        self.client_id = EMPTY_SLOT;
+        self.keep_alive = 0;
+        self.seq = 0;
+        self.drops = 0;
+    }
+    pub fn update(&mut self, now: u128, id: u32, loop_time: u128, seq: u32) -> () {
+        if self.keep_alive <= now {
+            let idx: usize = ((now - self.keep_alive) / 2667) as usize; // 2910 microsec per 128 sample frame
+            self.hist[idx.clamp(0, 9)] += 1;
+        }
+        if loop_time < MAX_LOOP_TIME {
+            // Only count loop times less than 100msec
+            self.loop_stat.get(loop_time as f64);
+        }
+        self.keep_alive = now;
+        self.client_id = id;
+        // Check sequence number
+        if self.seq + 1 != seq {
+            // We have a dropped packet
+            self.drops += 1;
+        }
+        self.seq = seq;
+    }
+    pub fn is_old(&self, now: u128) -> bool {
+        self.keep_alive + EXPIRATION_IN_MICROSECONDS < now
+    }
+    pub fn is_empty(&self) -> bool {
+        self.client_id == EMPTY_SLOT
+    }
+}
+
+#[cfg(test)]
+mod test_player {
+    use crate::common::get_micro_time;
+    use std::net::IpAddr;
+    use std::net::Ipv4Addr;
+
+    use super::*;
+
+    #[test]
+    fn build_player() {
+        let socket = SocketAddr::new(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)), 8080);
+        let player = Player::new(get_micro_time(), 44, socket);
+        println!("player: {}", serde_json::to_string(&player).unwrap());
+        assert_eq!(player.address, socket);
+    }
+}

--- a/src/common/player.rs
+++ b/src/common/player.rs
@@ -34,6 +34,7 @@ pub struct Player {
     hist: [usize; HISTOGRAM_BUCKETS], // histogram of packet arrivals
     loop_stat: SmoothingFilter,       // statistics about packet loop time
     pack_stats: StreamTimeStat,       // interarrival stats
+    packet_count: usize,              // count number of packets
 }
 
 impl Player {
@@ -47,6 +48,7 @@ impl Player {
             address: addr,
             loop_stat: SmoothingFilter::build(0.5, 2666.6),
             pack_stats: StreamTimeStat::new(100),
+            packet_count: 0,
         }
     }
     pub fn get_drops(&self) -> usize {
@@ -61,8 +63,10 @@ impl Player {
         self.keep_alive = 0;
         self.seq = 0;
         self.drops = 0;
+        self.packet_count = 0;
     }
     pub fn update(&mut self, now: u128, id: u32, loop_time: u128, seq: u32) -> () {
+        self.packet_count += 1;
         if self.keep_alive <= now {
             self.pack_stats.add_sample((now - self.keep_alive) as f64);
             let idx: usize = ((now - self.keep_alive) / 2667) as usize; // 2667 microsec per 128 sample frame

--- a/src/common/websock_message.rs
+++ b/src/common/websock_message.rs
@@ -1,0 +1,30 @@
+use serde_json::Value;
+
+use serde::Deserialize;
+use serde::Serialize;
+
+#[derive(Debug, Deserialize, Serialize)]
+
+pub enum WebsockMessage {
+    Chat(Value),
+    API(String, Value),
+}
+
+#[cfg(test)]
+mod test_websock_message {
+
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn make_chat() {
+        let chat = WebsockMessage::Chat(json!({ "name": "bob", "age": 32}));
+        let cjson = serde_json::to_value(chat).unwrap();
+        println!(
+            "chat json: {}",
+            serde_json::to_string_pretty(&cjson).unwrap()
+        );
+        let api = WebsockMessage::API(String::from("saveStats"), json!({"some": "stats"}));
+        dbg!(api);
+    }
+}

--- a/src/dsp/smoothing_filter.rs
+++ b/src/dsp/smoothing_filter.rs
@@ -1,8 +1,10 @@
 //! averaging filter use to smooth sequences
+use serde::Serialize;
 use std::fmt;
 
 use crate::utils::get_coef;
 
+#[derive(Serialize)]
 pub struct SmoothingFilter {
     coef: f64,
     last_output: f64,

--- a/src/server/audio_thread.rs
+++ b/src/server/audio_thread.rs
@@ -28,15 +28,15 @@ pub fn run(port: u32, audio_tx: mpsc::Sender<serde_json::Value>) -> Result<(), B
         let now_time = get_micro_time();
         // update the player list
         players.prune(now_time);
+        if latency_update_timer.expired(now_time) {
+            latency_update_timer.reset(now_time);
+            audio_tx.send(players.get_latency())?;
+            //     println!("got {} bytes from {}", amt, src);
+            println!("player: {}", players);
+            //     println!("msg: {}", msg);
+        }
         match res {
             Ok((amt, src)) => {
-                if latency_update_timer.expired(now_time) {
-                    latency_update_timer.reset(now_time);
-                    audio_tx.send(players.get_latency())?;
-                    //     println!("got {} bytes from {}", amt, src);
-                    println!("player: {}", players);
-                    //     println!("msg: {}", msg);
-                }
                 // check if the packet was good
                 if amt <= 0 || !msg.is_valid(amt) || !players.is_allowed(msg.get_client_id()) {
                     continue;

--- a/src/server/audio_thread.rs
+++ b/src/server/audio_thread.rs
@@ -4,11 +4,12 @@
 use crate::{
     common::{
         box_error::BoxError,
+        get_micro_time,
         jam_packet::{JamMessage, JAM_HEADER_SIZE},
         sock_with_tos,
         stream_time_stat::MicroTimer,
     },
-    server::player_list::{get_micro_time, PlayerList},
+    server::player_list::PlayerList,
 };
 use std::{io::ErrorKind, sync::mpsc, time::Duration};
 

--- a/src/server/player_list.rs
+++ b/src/server/player_list.rs
@@ -6,81 +6,8 @@ use std::collections::HashMap;
 use std::fmt;
 use std::net::SocketAddr;
 
-use crate::common::get_micro_time;
-use crate::dsp::smoothing_filter::SmoothingFilter;
+use crate::common::player::Player;
 
-// This is how long a player lasts until we boot them (if they go silent)
-const SERVER_EXPIRATION_IN_MICROSECONDS: u128 = 500000;
-
-///  structure that represents a player.  The players have
-///
-/// - client_id - assigned by the rtjam-nation to the player when they join a room
-/// - keep_alive - microsecond timestamp of the last time we saw this person
-/// - address - IP address to where we will forward packets
-/// - loop_stat - timing statistics for the player.
-pub struct Player {
-    pub client_id: u32,
-    pub keep_alive: u128,
-    pub address: SocketAddr,
-    pub loop_stat: SmoothingFilter,
-}
-
-// Only measure loop times up to 100msec
-pub const MAX_LOOP_TIME: u128 = 100_000;
-
-impl Player {
-    pub fn new(now_time: u128, id: u32, addr: SocketAddr) -> Player {
-        Player {
-            client_id: id,
-            keep_alive: now_time,
-            address: addr.clone(),
-            loop_stat: SmoothingFilter::build(0.5, 2666.6),
-        }
-    }
-    pub fn age(&self, now_time: u128) -> u128 {
-        now_time - self.keep_alive
-    }
-    pub fn update(&mut self, now_time: u128, id: u32, loop_time: u128) -> () {
-        if now_time > self.keep_alive {
-            if loop_time < MAX_LOOP_TIME {
-                // Only count loop times less than 100msec
-                self.loop_stat.get(loop_time as f64);
-            }
-            self.keep_alive = now_time;
-            self.client_id = id;
-        }
-    }
-}
-
-impl fmt::Display for Player {
-    // This trait requires `fmt` with this exact signature.
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(
-            f,
-            "{{ id: {}, address: {}, age: {} loop_time: {:.2} }}",
-            self.client_id,
-            self.address,
-            self.age(get_micro_time()),
-            self.loop_stat.get_last_output()
-        )
-    }
-}
-
-#[cfg(test)]
-mod test_player {
-    use std::net::IpAddr;
-    use std::net::Ipv4Addr;
-
-    use super::*;
-
-    #[test]
-    fn build_player() {
-        let socket = SocketAddr::new(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)), 8080);
-        let player = Player::new(get_micro_time(), 44, socket);
-        println!("player: {}", player);
-        assert_eq!(player.address, socket);
-    }
-}
 /// Structure to hold the list of players
 pub struct PlayerList {
     pub players: Vec<Player>,
@@ -106,11 +33,12 @@ impl PlayerList {
         loop_time: u128,
         id: u32,
         addr: SocketAddr,
+        seq: u32,
     ) -> () {
         // look for this player and update their timestamp if found
         for player in &mut self.players {
             if player.address == addr {
-                player.update(now_time, id, loop_time);
+                player.update(now_time, id, loop_time, seq);
                 return ();
             }
         }
@@ -120,8 +48,7 @@ impl PlayerList {
     /// look for any player entries that have timed out
     pub fn prune(&mut self, now_time: u128) -> () {
         // this function will age out any old Players
-        self.players
-            .retain(|p| p.keep_alive + SERVER_EXPIRATION_IN_MICROSECONDS > now_time);
+        self.players.retain(|p| !p.is_old(now_time));
     }
     /// Get a list of players to iterate though
     pub fn get_players(&self) -> &Vec<Player> {
@@ -134,7 +61,7 @@ impl PlayerList {
     pub fn get_latency(&mut self) -> serde_json::Value {
         let mut lmap: HashMap<u32, f64> = HashMap::new();
         for p in &self.players {
-            lmap.insert(p.client_id, p.loop_stat.get_last_output().round() / 1000.0);
+            lmap.insert(p.client_id, p.get_last_loop().round() / 1000.0);
             // Convert to msec
         }
         serde_json::json!({
@@ -146,9 +73,9 @@ impl PlayerList {
 impl fmt::Display for PlayerList {
     // This trait requires `fmt` with this exact signature.
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "[ ")?;
+        write!(f, "[\n")?;
         for player in &self.players {
-            write!(f, " {},", player)?;
+            write!(f, " {},\n", player)?;
         }
         write!(f, " ]")
     }
@@ -156,6 +83,7 @@ impl fmt::Display for PlayerList {
 #[cfg(test)]
 mod test_playerlist {
     use super::*;
+    use crate::common::{get_micro_time, player::EXPIRATION_IN_MICROSECONDS};
 
     #[test]
     fn build() {
@@ -182,16 +110,16 @@ mod test_playerlist {
             .parse()
             .expect("Unable to parse socket address");
         // Add a new player to an empty list
-        plist.update_player(now_time, loop_time, id, addr);
+        plist.update_player(now_time, loop_time, id, addr, 0);
         assert_eq!(plist.get_players().len(), 1);
         // this will update a player if we have seen them before
-        plist.update_player(now_time + 100, loop_time, id, addr);
+        plist.update_player(now_time + 100, loop_time, id, addr, 0);
         assert_eq!(plist.get_players().len(), 1);
         // This will add another player
         let addr: SocketAddr = "192.1.1.1:33345"
             .parse()
             .expect("Unable to parse socket address");
-        plist.update_player(now_time, loop_time, id, addr);
+        plist.update_player(now_time, loop_time, id, addr, 0);
         assert_eq!(plist.get_players().len(), 2);
     }
     #[test]
@@ -204,10 +132,10 @@ mod test_playerlist {
             .parse()
             .expect("Unable to parse socket address");
         // Add a new player to an empty list
-        plist.update_player(now_time, now_time, id, addr);
+        plist.update_player(now_time, now_time, id, addr, 0);
         assert_eq!(plist.get_players().len(), 1);
         // Call prune with a now_time that is past
-        plist.prune(now_time + SERVER_EXPIRATION_IN_MICROSECONDS + 1);
+        plist.prune(now_time + EXPIRATION_IN_MICROSECONDS + 1);
         assert_eq!(plist.get_players().len(), 0);
     }
     #[test]
@@ -219,7 +147,7 @@ mod test_playerlist {
             .parse()
             .expect("Unable to parse socket address");
         // Add a new player to an empty list
-        plist.update_player(now_time, now_time, id, addr);
+        plist.update_player(now_time, now_time, id, addr, 0);
         println!("latency: {}", plist.get_latency());
     }
 }

--- a/src/server/player_list.rs
+++ b/src/server/player_list.rs
@@ -5,17 +5,9 @@
 use std::collections::HashMap;
 use std::fmt;
 use std::net::SocketAddr;
-use std::time::{SystemTime, UNIX_EPOCH};
 
+use crate::common::get_micro_time;
 use crate::dsp::smoothing_filter::SmoothingFilter;
-
-// Get the time in microseconds
-pub fn get_micro_time() -> u128 {
-    SystemTime::now()
-        .duration_since(UNIX_EPOCH)
-        .unwrap()
-        .as_micros()
-}
 
 // This is how long a player lasts until we boot them (if they go silent)
 const SERVER_EXPIRATION_IN_MICROSECONDS: u128 = 500000;

--- a/src/sound/channel_map.rs
+++ b/src/sound/channel_map.rs
@@ -6,88 +6,16 @@
 //! your vocals on channel 6 and your guitar on channel 7"
 //!
 //! ### TODO
-//! this code has built in assumption that each "Client" has exactly two channels.  it
+//! this code has built in assumption that each "Player" has exactly two channels.  it
 //! fills slots based on first available and the two channels are always adjacent.
 use super::mixer::MIXER_CHANNELS;
-use serde::Serialize;
+use crate::common::player::{Player, EMPTY_SLOT};
 use std::fmt;
+use std::net::{IpAddr, Ipv4Addr, SocketAddr};
 
 // This is how long a player lasts until we boot them (if they go silent)
-const CLIENT_EXPIRATION_IN_MICROSECONDS: u128 = 1_000_000;
 const NUM_PLAYERS_IN_ROOM: usize = MIXER_CHANNELS / 2 - 1; // take away one cause the local guy is always in the room
-const EMPTY_SLOT: u32 = 40000;
 
-/// Structure that reprensents a Client
-///
-/// It has an ID, (assigned by rtjam-nation when they join a room)
-/// The keep_alive is used to time them out if we have not heard from them for over a second (no packets)
-#[derive(Serialize)]
-pub struct Client {
-    client_id: u32,
-    keep_alive: u128,
-    seq: u32,
-    drops: usize,
-    hist: [usize; 10],
-}
-
-impl Client {
-    pub fn new() -> Client {
-        Client {
-            client_id: EMPTY_SLOT,
-            keep_alive: 0,
-            seq: 0,
-            drops: 0,
-            hist: [0; 10],
-        }
-    }
-    pub fn get_id(&self) -> u32 {
-        self.client_id
-    }
-    pub fn get_drops(&self) -> usize {
-        self.drops
-    }
-    pub fn set_id(&mut self, id: u32) -> () {
-        self.client_id = id;
-    }
-    pub fn clear(&mut self) -> () {
-        self.hist = [0; 10];
-        self.client_id = EMPTY_SLOT;
-        self.keep_alive = 0;
-        self.seq = 0;
-        self.drops = 0;
-    }
-    pub fn update(&mut self, now: u128, seq: u32) -> () {
-        if self.keep_alive <= now {
-            let idx: usize = ((now - self.keep_alive) / 2667) as usize; // 2910 microsec per 128 sample frame
-            self.hist[idx.clamp(0, 9)] += 1;
-        }
-        self.keep_alive = now;
-        // Check sequence number
-        if self.seq + 1 != seq {
-            // We have a dropped packet
-            self.drops += 1;
-        }
-        self.seq = seq;
-    }
-    pub fn is_old(&self, now: u128) -> bool {
-        self.keep_alive + CLIENT_EXPIRATION_IN_MICROSECONDS < now
-    }
-    pub fn is_empty(&self) -> bool {
-        self.client_id == EMPTY_SLOT
-    }
-}
-
-#[cfg(test)]
-mod test_client_struct {
-
-    use super::*;
-
-    #[test]
-    fn can_serialize() {
-        let c = Client::new();
-        println!("client: {}", serde_json::to_string(&c).unwrap());
-    }
-}
 /// Map of the clients.
 ///
 /// There is no specific "add" function.  when you search for an ID and it's
@@ -96,53 +24,55 @@ mod test_client_struct {
 /// Note that the local user is always assigned slots 0 and 1.  Your channels
 /// are always the first two on the mixer
 pub struct ChannelMap {
-    clients: Vec<Client>,
+    players: Vec<Player>,
 }
 
 impl ChannelMap {
     /// Build a map
     pub fn new() -> ChannelMap {
-        let mut map = ChannelMap { clients: vec![] };
+        let mut map = ChannelMap { players: vec![] };
         for _ in 0..NUM_PLAYERS_IN_ROOM {
-            map.clients.push(Client::new());
+            map.players.push(Player::new(
+                0,
+                EMPTY_SLOT,
+                SocketAddr::new(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)), 9999),
+            ));
         }
         map
     }
     /// Mark all the slots as empty
     pub fn clear(&mut self) -> () {
-        for c in &mut self.clients {
-            c.client_id = EMPTY_SLOT;
-            c.keep_alive = 0;
+        for p in &mut self.players {
+            p.clear();
         }
     }
     /// see if any slots can be freed up (the guy left)
     pub fn prune(&mut self, now: u128) -> () {
         // search for aged clients
-        for c in &mut self.clients {
+        for c in &mut self.players {
             if !c.is_empty() && c.is_old(now) {
                 c.clear();
             }
         }
     }
     /// Get a list of the clients.  Used by the engine to dump out metadata to the u/x
-    pub fn get_clients(&self) -> &[Client] {
-        &self.clients
+    pub fn get_clients(&self) -> &[Player] {
+        &self.players
     }
     /// retrieve the first channel on the mixer where this client is assigned (remember they come in pairs)
     pub fn get_loc_channel(&mut self, id: u32, now: u128, seq: u32) -> Option<usize> {
         // search for this id
-        match self.clients.iter().position(|c| c.get_id() == id) {
+        match self.players.iter().position(|c| c.client_id == id) {
             Some(idx) => {
                 // Update the keepalive
-                self.clients[idx].update(now, seq);
+                self.players[idx].update(now, id, 0, seq);
                 Some((idx + 1) * 2)
             }
             None => {
                 // Nobody found with that ID.  Get first available slot
-                match self.clients.iter().position(|c| c.client_id == EMPTY_SLOT) {
+                match self.players.iter().position(|p| p.is_empty()) {
                     Some(idx) => {
-                        self.clients[idx].set_id(id);
-                        self.clients[idx].update(now, seq);
+                        self.players[idx].update(now, id, 0, seq);
                         Some((idx + 1) * 2)
                     }
                     None => None,
@@ -155,20 +85,20 @@ impl ChannelMap {
 impl fmt::Display for ChannelMap {
     // This trait requires `fmt` with this exact signature.
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "[ ")?;
-        for c in &self.clients {
+        write!(f, "[\n")?;
+        for c in &self.players {
             if !c.is_empty() {
                 write!(f, "{}\n,", serde_json::to_string(&c).unwrap())?;
             }
         }
-        write!(f, " ]")
+        write!(f, "]")
     }
 }
 
 #[cfg(test)]
 
 mod test_channel_map {
-    use crate::common::get_micro_time;
+    use crate::common::{get_micro_time, player::EXPIRATION_IN_MICROSECONDS};
 
     use super::*;
 
@@ -180,7 +110,7 @@ mod test_channel_map {
         assert_eq!(val, 2);
         let val_2 = map.get_loc_channel(4444, now, 1).unwrap();
         assert_eq!(val_2, 4);
-        map.prune(now + CLIENT_EXPIRATION_IN_MICROSECONDS + 1);
+        map.prune(now + EXPIRATION_IN_MICROSECONDS + 1);
         println!("after prune: {}", map);
     }
 }

--- a/src/sound/jam_engine.rs
+++ b/src/sound/jam_engine.rs
@@ -163,13 +163,13 @@ impl JamEngine {
         if self.debug_timer.expired(self.now) {
             self.debug_timer.reset(self.now);
             // println!("disconnect: {}", self.disconnect_timer.since(self.now));
-            println!(
-                "jack_jitter: {:.2}, {:.2}",
-                self.jack_jitter.get_mean(),
-                self.jack_jitter.get_sigma()
-            );
-            println!("mixer: {}", self.mixer);
-            println!("map: {}", self.chan_map);
+            // println!(
+            //     "jack_jitter: {:.2}, {:.2}",
+            //     self.jack_jitter.get_mean(),
+            //     self.jack_jitter.get_sigma()
+            // );
+            // println!("mixer: {}", self.mixer);
+            // println!("map: {}", self.chan_map);
         }
     }
     fn set_now(&mut self) -> () {

--- a/src/sound/jam_engine.rs
+++ b/src/sound/jam_engine.rs
@@ -289,7 +289,7 @@ impl JamEngine {
             if !c.is_empty() {
                 players.push(json!(
                     {
-                        "clientId": c.get_id(),
+                        "clientId": c.client_id,
                         "depth": self.mixer.get_depth_in_msec(idx),
                         "level0": self.mixer.get_channel_power_avg(idx),
                         "level1": self.mixer.get_channel_power_avg(idx+1),

--- a/src/sound/jam_engine.rs
+++ b/src/sound/jam_engine.rs
@@ -6,10 +6,14 @@ use std::{str::FromStr, sync::mpsc};
 use serde_json::json;
 
 use crate::{
-    common::{box_error::BoxError, jam_packet::JamMessage, stream_time_stat::MicroTimer},
+    common::{
+        box_error::BoxError,
+        get_micro_time,
+        jam_packet::JamMessage,
+        stream_time_stat::{MicroTimer, StreamTimeStat},
+    },
     dsp::tuner::Tuner,
     pedals::pedal_board::PedalBoard,
-    server::player_list::get_micro_time,
     utils::to_db,
 };
 
@@ -86,6 +90,7 @@ pub struct JamEngine {
     now: u128,
     pedal_boards: Vec<PedalBoard>,
     tuners: [Tuner; 2],
+    jack_jitter: StreamTimeStat,
 }
 
 impl JamEngine {
@@ -121,6 +126,7 @@ impl JamEngine {
             now: now,
             pedal_boards: vec![PedalBoard::new(), PedalBoard::new()],
             tuners: [Tuner::new(), Tuner::new()],
+            jack_jitter: StreamTimeStat::new(100),
         };
         // Set out client id to some rando number when not connected
         engine.xmit_message.set_client_id(4321);
@@ -157,12 +163,19 @@ impl JamEngine {
         if self.debug_timer.expired(self.now) {
             self.debug_timer.reset(self.now);
             // println!("disconnect: {}", self.disconnect_timer.since(self.now));
-            // println!("mixer: {}", self.mixer);
-            // println!("map: {}", self.chan_map);
+            println!(
+                "jack_jitter: {:.2}, {:.2}",
+                self.jack_jitter.get_mean(),
+                self.jack_jitter.get_sigma()
+            );
+            println!("mixer: {}", self.mixer);
+            println!("map: {}", self.chan_map);
         }
     }
     fn set_now(&mut self) -> () {
-        self.now = get_micro_time();
+        let now = get_micro_time();
+        self.jack_jitter.add_sample((now - self.now) as f64);
+        self.now = now;
     }
     fn check_disconnect(&mut self) -> () {
         if self.disconnect_timer.expired(self.now) {

--- a/src/sound/jam_socket.rs
+++ b/src/sound/jam_socket.rs
@@ -13,10 +13,7 @@
 //! This prevents the jitter buffer from having to have any mutexes. (one writer, one reader)
 use simple_error::bail;
 
-use crate::common::box_error::BoxError;
-use crate::common::jam_packet::JamMessage;
-use crate::common::sock_with_tos;
-use crate::server::player_list::get_micro_time;
+use crate::common::{box_error::BoxError, get_micro_time, jam_packet::JamMessage, sock_with_tos};
 use std::fmt;
 use std::net::UdpSocket;
 


### PR DESCRIPTION
This pull request will allow the broadcast component to save session packet statistics to rtjam-nation.

Things that were done are

- DRYed out code by using a single Player for both the broadcast PlayerList and sound ChannelMap
- Add a queue to save collected stats when a Player leaves a room
- Modify the websocket interface to allow actions as well as chat messages to be sent
- send a new API action that will save the packet stat to the rtjam-nation database