### PR TITLE
No loopback switch (issue #79)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,6 +8,9 @@ all:
 clean:
 	rm -rf target/release/examples/*
 
+debug:
+	cargo build --package rtjam_rust --example rtjam_broadcast --example rtjam_sound
+
 deploy: all
 	scp -i ~/.ssh/rtjam.cer target/release/examples/rtjam_sound  ubuntu@rtjam-nation.com:/home/ubuntu/www/html/pi/rust
 	scp -i ~/.ssh/rtjam.cer target/release/examples/rtjam_broadcast  ubuntu@rtjam-nation.com:/home/ubuntu/www/html/pi/rust

--- a/src/common/config.rs
+++ b/src/common/config.rs
@@ -133,7 +133,43 @@ mod test {
         assert_eq!(bob, "bob");
     }
     
-    // TODO: add tests for get_<type>_value functions
+    #[test]
+    fn get_bool_value_default() {
+        // You should be able to get a bool value with a default
+        let config = Config::build();
+        let value = config.get_bool_value("i_dont_exist", false);
+        assert_eq!(value, false);
+    }
+
+    #[test]
+    fn get_bool_value() {
+        // You should be able to get a bool value
+        let config = Config{
+            filename: String::from("no_file"),
+            settings: json::object! {
+                "the_truth": true
+            },
+        };
+        let value = config.get_bool_value("the_truth", false);
+        assert_eq!(value, true);
+    }
+
+    #[test]
+    fn get_bool_value_invalid() {
+        // A non-bool JSON type should be handled gracefully, with a default value and log a warning
+        let config = Config{
+            filename: String::from("no_file"),
+            settings: json::object! {
+                "should_be_bool": "not a bool"
+            },
+        };
+        let value = config.get_bool_value("should_be_bool", true);
+        assert_eq!(value, true);
+        // TODO: validate that a warning was logged to console
+        // use the captured output crate for this? 
+    }
+   
+    // TODO: add tests for the other get_<type>_value functions
 
     #[test]
     fn set_value() {

--- a/src/common/config.rs
+++ b/src/common/config.rs
@@ -45,7 +45,6 @@ impl Config {
             Some(i) => i,
         }
     }
-
     pub fn get_u32_value(&self, key: &str, def_value: u32) -> u32 {
         let val = self.settings[key].as_u32();
         match val {
@@ -53,9 +52,8 @@ impl Config {
             Some(i) => i,
         }
     }
-
     pub fn get_bool_value(&self, key: &str, def_value: bool) -> bool {
-        // expects JSON value as type bool (unquoted), any string or numeric will evaluate to true
+        // expects JSON value as type bool (unquoted), any string and bad things happen
         let val = self.settings[key].as_bool();
         match val {
             None => def_value,
@@ -134,6 +132,9 @@ mod test {
         let bob = config.get_value("bob", "bob");
         assert_eq!(bob, "bob");
     }
+    
+    // TODO: add tests for get_<type>_value functions
+
     #[test]
     fn set_value() {
         // You should be able to set a value on a key

--- a/src/common/config.rs
+++ b/src/common/config.rs
@@ -54,6 +54,15 @@ impl Config {
         }
     }
 
+    pub fn get_bool_value(&self, key: &str, def_value: bool) -> bool {
+        // expects JSON value as type bool (unquoted), any string or numeric will evaluate to true
+        let val = self.settings[key].as_bool();
+        match val {
+            None => def_value,
+            Some(i) => i,
+        }
+    }
+
     pub fn set_value(&mut self, key: &str, val: &str) -> () {
         self.settings[key] = val.into();
     }

--- a/src/sound/client.rs
+++ b/src/sound/client.rs
@@ -95,9 +95,11 @@ pub fn run(git_hash: &str) -> Result<(), BoxError> {
     let (command_tx, command_rx): (mpsc::Sender<ParamMessage>, mpsc::Receiver<ParamMessage>) =
         mpsc::channel();
 
-    println!("fetching no_loopback setting...");
     let no_loopback = config.get_bool_value("no_loopback", false);
-    println!("no_loopback={}", no_loopback);
+    if no_loopback {
+        println!("local loopback disabled");
+    }
+    
     let engine = JamEngine::new(status_data_tx, command_rx, api.get_token(), git_hash, no_loopback)?;
     let _jack_thread_handle = thread::spawn(move || {
         let _res = jack_thread::run(engine);

--- a/src/sound/client.rs
+++ b/src/sound/client.rs
@@ -95,11 +95,9 @@ pub fn run(git_hash: &str) -> Result<(), BoxError> {
     let (command_tx, command_rx): (mpsc::Sender<ParamMessage>, mpsc::Receiver<ParamMessage>) =
         mpsc::channel();
 
-    let no_loopback_param = config.get_value("no_loopback", "false");
-    let no_loopback = match no_loopback_param {
-       "true" => true,
-       _ => false
-    };
+    println!("fetching no_loopback setting...");
+    let no_loopback = config.get_bool_value("no_loopback", false);
+    println!("no_loopback={}", no_loopback);
     let engine = JamEngine::new(status_data_tx, command_rx, api.get_token(), git_hash, no_loopback)?;
     let _jack_thread_handle = thread::spawn(move || {
         let _res = jack_thread::run(engine);

--- a/src/sound/client.rs
+++ b/src/sound/client.rs
@@ -95,7 +95,12 @@ pub fn run(git_hash: &str) -> Result<(), BoxError> {
     let (command_tx, command_rx): (mpsc::Sender<ParamMessage>, mpsc::Receiver<ParamMessage>) =
         mpsc::channel();
 
-    let engine = JamEngine::new(status_data_tx, command_rx, api.get_token(), git_hash)?;
+    let no_loopback_param = config.get_value("no_loopback", "false");
+    let no_loopback = match no_loopback_param {
+       "true" => true,
+       _ => false
+    };
+    let engine = JamEngine::new(status_data_tx, command_rx, api.get_token(), git_hash, no_loopback)?;
     let _jack_thread_handle = thread::spawn(move || {
         let _res = jack_thread::run(engine);
     });

--- a/src/sound/jam_engine.rs
+++ b/src/sound/jam_engine.rs
@@ -515,7 +515,7 @@ mod test_jam_engine {
         let (_command_tx, command_rx): (mpsc::Sender<ParamMessage>, mpsc::Receiver<ParamMessage>) =
             mpsc::channel();
 
-        JamEngine::new(status_data_tx, command_rx, "someToken", "some_git_hash").unwrap()
+        JamEngine::new(status_data_tx, command_rx, "someToken", "some_git_hash", false).unwrap()
     }
 
     #[test]


### PR DESCRIPTION
Add optional JSON value to `settings.json`:
`"no_loopback": <bool>`
Default value is _false_
_Note_: uses the JSON bool type (no quotes on value)
When set to true, JamEngine will not put the local channels into the incoming mix stream, preventing a local loopback of the audio sent from the client to the server. 

Implemented Config::get_bool_value() to fetch booleans from settings.json. 

_Note_: Config will blow up if there's an invalid JSON structure in the settings.json. 