### PR TITLE
improvements to how the software gets downloaded/updated

### DIFF
--- a/docs/pi-scripts/jackrun.bash
+++ b/docs/pi-scripts/jackrun.bash
@@ -11,7 +11,7 @@ $WGET -O $WEBVER $NATION/$WEBVER
 if [ "$?" -ne "0" ]; then
   # not able to get the web version, so we will just continue on and run
   # This is likely the no network scenario or the server is down for maintenance
-  echo "could not get version from server"
+  echo "Cannot contact the nation:  no version from server"
 else
   # Get the version number out of the local program
   ./$PROGRAM --version > $LOCALVER
@@ -25,12 +25,13 @@ else
   cmp -s $WEBVER $LOCALVER
   if [ "$?" -ne "0" ]; then
     # There is a new version on the web  Stash the old one
-    echo "New version available"
+    echo "New version available, gonna download"
     mkdir -p rollback
     cp -f $PROGRAM rollback
     $WGET -O $PROGRAM $NATION/$PROGRAM
     if [ "$?" -ne "0" ]; then
       # Something went wrong fetching the program file.  rollback
+      echo "failed to download new version.  Rollback"
       cp -f rollback/$PROGRAM $PROGRAM
     else
       # We successfully downloaded the program
@@ -39,6 +40,7 @@ else
       ./$PROGRAM --version 
       if [ "$?" -ne "0" ]; then
         # Yikes, the thing we downloaded wont run here.  better rollback
+        echo "Something wrong with new version, rollback!"
         cp -f rollback/$PROGRAM $PROGRAM
       fi
     fi

--- a/docs/pi-scripts/jackrun.bash
+++ b/docs/pi-scripts/jackrun.bash
@@ -5,61 +5,65 @@ LOCALVER=version.local.txt
 PROGRAM=rtjam_sound
 # This is how we will fetch from the network
 WGET='wget -q --tries=2 --timeout=3'
-# Step one is to get the version of the software on the web
-rm $WEBVER
-$WGET -O $WEBVER $NATION/$WEBVER
-if [ "$?" -ne "0" ]; then
-  # not able to get the web version, so we will just continue on and run
-  # This is likely the no network scenario or the server is down for maintenance
-  echo "Cannot contact the nation:  no version from server"
-else
-  # Get the version number out of the local program
-  ./$PROGRAM --version > $LOCALVER
+
+if [ -z $SKIP_UPDATE ]; then
+  # Step one is to get the version of the software on the web
+  rm $WEBVER
+  $WGET -O $WEBVER $NATION/$WEBVER
   if [ "$?" -ne "0" ]; then
-    # This is an error so the rtjam_sound is corrupt.  Do the recovery here....
-    echo "program will not give version.  something wrong with it"
-    # TODO:  Should we do this here?  Get the version stashed in rollback
-    # cp -f rollback/$PROGRAM $PROGRAM
-  fi
-  # compare the local version with the one on the web
-  cmp -s $WEBVER $LOCALVER
-  if [ "$?" -ne "0" ]; then
-    # There is a new version on the web  Stash the old one
-    echo "New version available, gonna download"
-    mkdir -p rollback
-    cp -f $PROGRAM rollback
-    $WGET -O $PROGRAM $NATION/$PROGRAM
-    if [ "$?" -ne "0" ]; then
-      # Something went wrong fetching the program file.  rollback
-      echo "failed to download new version.  Rollback"
-      cp -f rollback/$PROGRAM $PROGRAM
-    else
-      # We successfully downloaded the program
-      chmod +x $PROGRAM
-      # Make sure the executable will run a version
-      ./$PROGRAM --version 
-      if [ "$?" -ne "0" ]; then
-        # Yikes, the thing we downloaded wont run here.  better rollback
-        echo "Something wrong with new version, rollback!"
-        cp -f rollback/$PROGRAM $PROGRAM
-      fi
-    fi
+    # not able to get the web version, so we will just continue on and run
+    # This is likely the no network scenario or the server is down for maintenance
+    echo "Cannot contact the nation:  no version from $NATION"
   else
-    echo "Softare is up to date"
+    # Get the version number out of the local program
+    ./$PROGRAM --version > $LOCALVER
+    if [ "$?" -ne "0" ]; then
+      # This is an error so the rtjam_sound is corrupt.  Do the recovery here....
+      echo "program will not give version.  something wrong with it"
+      # TODO:  Should we do this here?  Get the version stashed in rollback
+      # cp -f rollback/$PROGRAM $PROGRAM
+    fi
+    # compare the local version with the one on the web
+    cmp -s $WEBVER $LOCALVER
+    if [ "$?" -ne "0" ]; then
+      # There is a new version on the web  Stash the old one
+      echo "New version available, gonna download"
+      cp -f $PROGRAM $PROGRAM.rollback
+      $WGET -O $PROGRAM $NATION/$PROGRAM
+      if [ "$?" -ne "0" ]; then
+        # Something went wrong fetching the program file.  rollback
+        echo "failed to download new version.  Rollback"
+        cp -f $PROGRAM.rollback $PROGRAM
+      else
+        # We successfully downloaded the program
+        chmod +x $PROGRAM
+        # Make sure the executable will run a version
+        ./$PROGRAM --version 
+        if [ "$?" -ne "0" ]; then
+          # Yikes, the thing we downloaded wont run here.  better rollback
+          echo "Something wrong with new version, rollback!"
+          cp -f $PROGRAM.rollback $PROGRAM
+        fi
+      fi
+    else
+      echo "Software is up to date"
+    fi
   fi
+else
+  echo "Skipping Update"
 fi
 # Check for soundin.cfg
 if [ -f soundin.cfg ];
 then
   INDEV=`cat soundin.cfg`
 else
-  INDEV=hw:CODEC
+  INDEV=plughw:CODEC
   echo $INDEV > soundin.cfg
 fi
 # make sure there was something in the file
 if [ -z ${INDEV} ];
 then 
-  INDEV=USB 
+  INDEV=plughw:CODEC
 fi
 if [ -f soundout.cfg ];
 then


### PR DESCRIPTION
Make the jackrun.bash script more robust to handle 

- no network availabe (improve timeouts and retries
- save a copy of working executable in case downloaded version  will not run on this system
- rollback to previous version when dowload fails or is corrupted