### PR TITLE
Metronome and Click Track support

### DIFF
--- a/src/common/stream_time_stat.rs
+++ b/src/common/stream_time_stat.rs
@@ -119,6 +119,10 @@ impl MicroTimer {
     pub fn since(&mut self, now: u128) -> u128 {
         now - self.last_time
     }
+    /// get the current timer interval
+    pub fn get_interval(&self) -> u128 {
+        self.interval
+    }
 }
 
 #[cfg(test)]

--- a/src/server.rs
+++ b/src/server.rs
@@ -6,3 +6,4 @@ pub mod player_list;
 pub mod playback_thread;
 pub mod room_mixer;
 pub mod ping_thread;
+pub mod metronome;

--- a/src/server/metronome.rs
+++ b/src/server/metronome.rs
@@ -4,17 +4,23 @@ use crate::common::{get_micro_time, stream_time_stat::MicroTimer};
 pub struct Metronome {
     beat: u8,
     duration: MicroTimer,
+    tempo: u128,
 }
 
 impl Metronome {
     pub fn new() -> Metronome {
         Metronome {
             beat: 0,
+            tempo: 120,
             duration: MicroTimer::new(get_micro_time(), 1_000_000 * 60 / 120), // 120BPM in microseconds
         }
     }
     pub fn set_tempo(&mut self, now_time: u128,  tempo: u128) -> () {
+        self.tempo = tempo;
         self.duration = MicroTimer::new(now_time, 1_000_000 * 60 / tempo);
+    }
+    pub fn get_tempo(&self) -> u128 {
+        self.tempo
     }
     pub fn get_beat_interval(&self) -> u128 {
         self.duration.get_interval()

--- a/src/server/metronome.rs
+++ b/src/server/metronome.rs
@@ -1,0 +1,55 @@
+use crate::common::{get_micro_time, stream_time_stat::MicroTimer};
+
+
+pub struct Metronome {
+    beat: u8,
+    duration: MicroTimer,
+}
+
+impl Metronome {
+    pub fn new() -> Metronome {
+        Metronome {
+            beat: 0,
+            duration: MicroTimer::new(get_micro_time(), 1_000_000 * 60 / 120), // 120BPM in microseconds
+        }
+    }
+    pub fn set_tempo(&mut self, now_time: u128,  tempo: u128) -> () {
+        self.duration = MicroTimer::new(now_time, 1_000_000 * 60 / tempo);
+    }
+    pub fn get_beat_interval(&self) -> u128 {
+        self.duration.get_interval()
+    }
+    pub fn get_beat(&mut self, now_time: u128)  -> u8 {
+        if self.duration.expired(now_time) {
+            self.duration.advance(self.duration.get_interval());
+            self.beat += 1;
+        }
+        self.beat = self.beat % 4;
+        self.beat
+    }
+    pub fn reset_time(&mut self, now_time: u128) -> () {
+        self.duration.reset(now_time);
+    }
+}
+
+#[cfg(test)]
+mod test_metronome {
+    use super::*;
+
+    #[test]
+    fn test_beat() {
+        let now = 1000;
+        let mut met = Metronome::new();
+        met.set_tempo(now, 120);
+        assert_eq!(met.get_beat_interval(), 1_000_000 / 2); // 120BPM = 500_000 microseconds
+        assert_eq!(met.get_beat(now), 0);
+        assert_eq!(met.get_beat(now + 499_999), 0);
+        assert_eq!(met.get_beat(now + 500_001), 1);
+        assert_eq!(met.get_beat(now + 500_001), 1);
+        assert_eq!(met.get_beat(now + 1_000_001), 2);
+        assert_eq!(met.get_beat(now + 1_000_001), 2);
+        assert_eq!(met.get_beat(now + 1_500_001), 3);
+        assert_eq!(met.get_beat(now + 2_000_001), 0);
+        assert_eq!(met.get_beat(now + 2_500_001), 1);
+    }
+}

--- a/src/server/playback_thread.rs
+++ b/src/server/playback_thread.rs
@@ -98,7 +98,7 @@ impl PlaybackMixer {
             // We are currently playing back.  Mix out a packet
             let mut out_a: [f32; 128] = [0.0; 128];
             let mut out_b: [f32; 128] = [0.0; 128];
-            self.mixer.get_mix(&mut out_a, &mut out_b);
+            self.mixer.get_mix(0, &mut out_a, &mut out_b);
             let mut packet = JamMessage::new();
             packet.set_client_id(40001);
             packet.set_sequence_num(self.seq);
@@ -118,7 +118,7 @@ impl PlaybackMixer {
             // We are currently playing back.  Mix out a packet
             let mut out_a: [f32; 128] = [0.0; 128];
             let mut out_b: [f32; 128] = [0.0; 128];
-            self.mixer.get_mix(&mut out_a, &mut out_b);
+            self.mixer.get_mix(0, &mut out_a, &mut out_b);
             return Some([out_a, out_b]);
         }
         None

--- a/src/server/player_list.rs
+++ b/src/server/player_list.rs
@@ -68,23 +68,20 @@ impl PlayerList {
     pub fn get_players(&self) -> &Vec<Player> {
         &self.players
     }
-
+    pub fn get_update_cnt(&self) -> usize {
+        self.update_cnt
+    }
     /// Get a json representation of the players in the room and their current latency
     ///
     /// used to update other players in the room about the status of everybody's connection
-    pub fn get_latency(&mut self, mode: bool) -> serde_json::Value {
+    pub fn get_latency(&mut self) -> Vec<(u32, f64)> {
         self.update_cnt += 1;
         let mut list: Vec<(u32, f64)> = vec![];
         for p in &self.players {
             // Convert to msec
             list.push((p.client_id, p.get_last_loop().round() / 1000.0));
         }
-        serde_json::json!({
-            "speaker": "RoomChatRobot",
-            "mode": mode,
-            "latency": list,
-            "update_count": self.update_cnt,
-        })
+        list
     }
 }
 
@@ -170,6 +167,6 @@ mod test_playerlist {
             .expect("Unable to parse socket address");
         // Add a new player to an empty list
         plist.update_player(now_time, now_time, id, addr, 0);
-        println!("latency: {}", plist.get_latency(true));
+        println!("latency: {:?}", plist.get_latency());
     }
 }

--- a/src/server/room_mixer.rs
+++ b/src/server/room_mixer.rs
@@ -43,7 +43,7 @@ impl RoomMixer {
         // Mix out a packet
         let mut out_a: [f32; 128] = [0.0; 128];
         let mut out_b: [f32; 128] = [0.0; 128];
-        self.mixer.get_mix(&mut out_a, &mut out_b);
+        self.mixer.get_mix(0, &mut out_a, &mut out_b);
         let mut packet = JamMessage::new();
         packet.set_client_id(40002);
         packet.set_sequence_num(self.seq);

--- a/src/sound.rs
+++ b/src/sound.rs
@@ -21,3 +21,4 @@ pub mod jam_socket;
 pub mod jitter_buffer;
 pub mod mixer;
 pub mod param_message;
+pub mod click_track;

--- a/src/sound/click_track.rs
+++ b/src/sound/click_track.rs
@@ -1,0 +1,76 @@
+//!
+//! object to provide a click track on beat changes
+//! 
+
+use pedal_board::dsp::low_freq_osc::{LowFreqOsc, WaveShape};
+
+pub struct ClickTrack {
+    gain: f32,
+    beat: u8,
+    tic: Vec<f32>,
+    toc: Vec<f32>,
+    idx: usize,
+    mute: bool,
+}
+
+const CLICK_SIZE: usize = 4800;
+
+impl ClickTrack {
+    pub fn new() -> ClickTrack {
+        let mut rval = ClickTrack {
+            gain: 1.0,
+            mute: true,
+            beat: 0,
+            tic: vec![],
+            toc: vec![],
+            idx: 0,
+        };
+        let mut i = 0;
+        let mut osc: LowFreqOsc<f32> = LowFreqOsc::new();
+        osc.init(WaveShape::Sine, 330.0, 1.0, 48_000.0);
+        while i < CLICK_SIZE {
+            rval.tic.push(osc.get_sample());
+            i += 1;
+        }
+        i = 0;
+        osc.init(WaveShape::Sine, 300.0, 0.7, 48_000.0);
+        while i < CLICK_SIZE {
+            rval.toc.push(osc.get_sample());
+            i += 1;
+        }
+        rval
+    }
+    pub fn get_gain(&self) -> f64 {
+        self.gain as f64
+    }
+    pub fn get_mute(&self) -> bool {
+        self.mute
+    }
+    pub fn set_gain(&mut self, gain: f64) -> () {
+        self.gain = gain as f32;
+    }
+    pub fn set_mute(&mut self, mute: bool) -> () {
+        self.mute = mute;
+    }
+    pub fn mix_into(&mut self, beat: u8, out_a: &mut [f32], out_b: &mut [f32]) -> () {
+        // this is where we mix in the click
+        if beat != self.beat {
+            self.beat = beat;
+            self.idx = 0;
+        }
+        if !self.mute && self.idx < CLICK_SIZE - out_a.len() {
+            let mut i: usize = 0;
+            while i < out_a.len() {
+                if beat == 0 {
+                    out_a[i] += self.gain * self.tic[self.idx+i];
+                    out_b[i] += self.gain * self.tic[self.idx+i];
+                } else {
+                    out_a[i] += self.gain * self.toc[self.idx+i];
+                    out_b[i] += self.gain * self.toc[self.idx+i];
+                }
+                i += 1;
+            }
+            self.idx += out_a.len();
+        }
+    }
+}

--- a/src/sound/param_message.rs
+++ b/src/sound/param_message.rs
@@ -50,6 +50,8 @@ pub enum JamParam {
     SetBufferSize,  // Changes the framesize (experimental for Joel, did not help)
     ChannelMute,  // Set the must stus on a channel
     ChannelGain,  // Set the channel gain (replaces ChanGain1-14)
+    MetronomeGain, // Set the gain on the metronome
+    MetronomeMute, // Mute/unMute metronome
     Count,  // Count of basic apis  (not really used)
     SetAudioInput = 1000,
     SetAudioOutput,
@@ -158,7 +160,7 @@ impl fmt::Display for ParamMessage {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(
             f,
-            "{{ param: {}, ival_1: {}, ival_2: {}, fval: {} sval: {} }}",
+            "{{ param: {}, ivalue_1: {}, ivalue_2: {}, fvalue: {} svalue: {} }}",
             ToPrimitive::to_i64(&self.param).unwrap(),
             self.ivalue_1,
             self.ivalue_2,


### PR DESCRIPTION
Server changes to mark the current beat in the server packets.  Client changes to generate a click based on that beat.