### PR TITLE
Fix logic error on range check and step size for pots

### DIFF
--- a/src/hw_control/codec_control.rs
+++ b/src/hw_control/codec_control.rs
@@ -154,9 +154,9 @@ impl CodecControl {
                 AdcValue::new(),
             ],
             pots: [
-                PotValue::new("Input One", 0.0, 1.0, 0.008),
-                PotValue::new("Input Two", 0.0, 1.0, 0.008),
-                PotValue::new("Headphone", 0.0, 1.0, 0.008),
+                PotValue::new("Input One", 0.0, 1.0, 0.012),
+                PotValue::new("Input Two", 0.0, 1.0, 0.012),
+                PotValue::new("Headphone", 0.0, 1.0, 0.012),
             ],
         })
     }

--- a/src/hw_control/codec_control.rs
+++ b/src/hw_control/codec_control.rs
@@ -154,9 +154,9 @@ impl CodecControl {
                 AdcValue::new(),
             ],
             pots: [
-                PotValue::new("Input One", 0.0, 1.0, 0.012),
-                PotValue::new("Input Two", 0.0, 1.0, 0.012),
-                PotValue::new("Headphone", 0.0, 1.0, 0.012),
+                PotValue::new("Input One", 0.0, 1.0, 0.02),
+                PotValue::new("Input Two", 0.0, 1.0, 0.02),
+                PotValue::new("Headphone", 0.0, 1.0, 0.02),
             ],
         })
     }

--- a/src/hw_control/hw_control_thread.rs
+++ b/src/hw_control/hw_control_thread.rs
@@ -49,13 +49,13 @@ pub fn hw_control_thread(
                         info!("input_1_gain: {}, input_2_gain: {}, headphone_gain: {}", input_1_gain, input_2_gain, headphone_gain);
                         match codec_option {
                             Some(ref mut codec) => {
-                                if (input_1_gain >= 0.0) || (input_1_gain <= 1.0) {
+                                if (input_1_gain >= 0.0) && (input_1_gain <= 1.0) {
                                     codec.update_input_one_gain(input_1_gain)?;
                                 }
-                                if (input_2_gain >= 0.0) || (input_2_gain <= 1.0) {
+                                if (input_2_gain >= 0.0) && (input_2_gain <= 1.0) {
                                     codec.update_input_two_gain(input_2_gain)?;
                                 }
-                                if (headphone_gain >= 0.0) || (headphone_gain <= 1.0) {
+                                if (headphone_gain >= 0.0) && (headphone_gain <= 1.0) {
                                     codec.update_headphone_gain(headphone_gain)?;
                                 }
                             }


### PR DESCRIPTION
Range Check on updates was using || instead of &&  (rookie mistake)
Increase step size to prevent volume bouncing on pot 3 adc read